### PR TITLE
refact: moves most of weight updating logic into Weights

### DIFF
--- a/src/main/java/dev/jimstockwell/rumelhart1985/Network.java
+++ b/src/main/java/dev/jimstockwell/rumelhart1985/Network.java
@@ -336,10 +336,10 @@ class Network implements Cloneable
 
     Weights newWeights(Deltas deltas)
     {
-        var array = IntStream.range(1,structure.length)
-                             .mapToObj(layer->newLayerOfWeights(layer,deltas))
-                             .toArray(double[][][]::new);
-        return new Weights(array);
+        Weights.ThreeIntFunction<Double> x = (layer,out,in) ->
+             η * deltas.getDelta(layer,out) * outputs.get(layer,in);
+
+        return weights.nextWeights(x);
     }
 
     double[][] newTheta(Deltas deltas)
@@ -357,32 +357,6 @@ class Network implements Cloneable
         return IntStream.range(0,structure[layer])
                         .mapToDouble(getTheta)
                         .toArray();
-    }
-
-    private double[][] newLayerOfWeights(int layer, Deltas deltas)
-    {
-        IntFunction<double[]> getInputWeights =
-                 outNode -> newNodeInputWeights( deltas, layer-1, outNode);
-
-        return IntStream.range(0,structure[layer])
-                        .mapToObj(getInputWeights)
-                        .toArray(double[][]::new);
-    }
-
-    /**
-     * Returns a new updated instance of input weights
-     * for the specified node.
-     */
-    private double[] newNodeInputWeights(Deltas deltas, int wLayer, int outNode)
-    {
-        IntFunction<Double> adj =
-            inNode -> η *
-                      deltas.getDelta(wLayer,outNode) *
-                      outputs.get(wLayer,inNode);
-
-        return weights.getFanningInWeights(wLayer, outNode)
-                      .withAdjustment(adj)
-                      .toPrimitiveArray();
     }
 
 

--- a/src/test/java/dev/jimstockwell/rumelhart1985/ArrayDeltasTest.java
+++ b/src/test/java/dev/jimstockwell/rumelhart1985/ArrayDeltasTest.java
@@ -3,7 +3,6 @@ package dev.jimstockwell.rumelhart1985;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Disabled;
 
 public class ArrayDeltasTest 
 {

--- a/src/test/java/dev/jimstockwell/rumelhart1985/WeightsTest.java
+++ b/src/test/java/dev/jimstockwell/rumelhart1985/WeightsTest.java
@@ -3,7 +3,6 @@ package dev.jimstockwell.rumelhart1985;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Disabled;
 
 public class WeightsTest 
 {
@@ -54,5 +53,16 @@ public class WeightsTest
         assertThrows(
             IllegalStateException.class,
             () -> new Weights(new double[][][] {}).structure());
+    }
+
+    @Test
+    public void notAViewOrPartialView()
+    {
+        Double[][][] array = new Double[][][]
+            {{{1.0}}};
+        Weights w = new Weights(array);
+        assertEquals(1,w.getWeight(0,0,0));
+        array[0][0][0] = 2.0;
+        assertEquals(1,w.getWeight(0,0,0));
     }
 }


### PR DESCRIPTION
Moves much code from "Network" to "Weights" where it more properly belongs.